### PR TITLE
add file based RS-485 direction control

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Usage:
        -h     Usage help.
        -d     Instruct mbusd not to fork itself (non-daemonize).
        -t     Enable RTS RS-485 data direction control (if not disabled while compile).
+       -y file
+              Enable RS-485 direction data direction control by writing '1' to file
+              for transmitter enable and '0' to file for transmitter disable
+       -Y file
+              Enable RS-485 direction data direction control by writing '0' to file
+              for transmitter enable and '1' to file for transmitter disable
        -v level
               Specifies  log  verbosity level (0 for errors only, 1 for warnings
               and 2 for also information messages.) If mbusd was compiled in debug mode,
@@ -106,6 +112,9 @@ Credits:
 Andrew Denysenko (<nitr0@seti.kr.ua>):
  - RTS RS-485 data direction control
  - RTU response receiving by length
+
+James Jarvis (<jj@aprsworld.com>):
+ - file based RS-485 data direction control
 
 License:
 --------

--- a/doc/mbusd.8.in
+++ b/doc/mbusd.8.in
@@ -37,6 +37,12 @@ Usage help.
 Instruct \fImbusd\fR not to fork itself (non-daemonize).
 .IP \fB-t\fR
 Enable RTS RS-485 data direction control (if not disabled while compile).
+.IP "\fB-y \fIfile\fR"
+Enable RS-485 direction data direction control by writing '1' to file
+for transmitter enable and '0' to file for transmitter disable
+.IP "\fB-Y \fIfile\fR"
+Enable RS-485 direction data direction control by writing '0' to file
+for transmitter enable and '1' to file for transmitter disable
 .IP "\fB-v \fIlevel\fR"
 Specifies log verbosity level. 0 enables logging of errors only,
 1 also enables warnings and 2 enables information messages.

--- a/doc/mbusd.8.in
+++ b/doc/mbusd.8.in
@@ -6,6 +6,10 @@ mbusd \- MODBUS/TCP to MODBUS/RTU gateway.
 .RB [ -h ]
 .RB [ -d ]
 .RB [ -t ]
+.RB [ -y
+.IR file ]
+.RB [ -Y
+.IR file ]
 .RB [ -v
 .IR level ]
 .RB [ -L

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -56,6 +56,8 @@ typedef struct
   char *ttymode;
   /* trx control type (0 - ADDC, 1 - by RTS, 2 - by sysfs GPIO with 1 activating transmit, 3 - by sysfs GPIO with 0 activating transmit) */
   int trxcntl;
+  /* trx control sysfs file */
+  char trxcntl_file[INTBUFSIZE + 1];
   /* TCP server port number */
   int serverport;
   /* maximum number of connections */

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -54,7 +54,7 @@ typedef struct
   int ttyspeed;
   /* tty mode */
   char *ttymode;
-  /* trx control type (0 - ADDC, 1 - by RTS) */
+  /* trx control type (0 - ADDC, 1 - by RTS, 2 - by sysfs GPIO with 1 activating transmit, 3 - by sysfs GPIO with 0 activating transmit) */
   int trxcntl;
   /* TCP server port number */
   int serverport;

--- a/src/conn.c
+++ b/src/conn.c
@@ -248,7 +248,7 @@ conn_write(int d, void *buf, size_t nbytes, int istty)
   long delay;
 #ifdef TRXCTL
   if (istty) {
-    if (cfg.trxcntl == TRX_RTS)
+    if (cfg.trxcntl != TRX_ADDC )
       tty_set_rts(d);
     usleep(35000000l/cfg.ttyspeed);
   }
@@ -278,7 +278,7 @@ conn_write(int d, void *buf, size_t nbytes, int istty)
     usleep(delay);
 #endif
 /*    tcdrain(d); - hangs sometimes, so make calculated delay */
-    if (cfg.trxcntl == TRX_RTS) {
+    if (cfg.trxcntl != TRX_ADDC ) {
       tty_clr_rts(d);
     }
   }

--- a/src/main.c
+++ b/src/main.c
@@ -104,7 +104,7 @@ usage(char *exename)
    "Andrew Denysenko <nitr0@seti.kr.ua>\n\n"
    "Usage: %s [-h] [-d] "
 #ifdef TRXCTL
-   "[-t] "
+   "[-t] [-y sysfsfile] [-Y sysfsfile]\n"
 #endif
    "[-v level] [-L logfile] [-p device] [-s speed] [-m mode] [-P port]\n"
    "             [-C maxconn] [-N retries] [-R pause] [-W wait] [-T timeout]\n\n"
@@ -112,7 +112,9 @@ usage(char *exename)
    "  -h         : this help\n"
    "  -d         : don't daemonize\n"
 #ifdef TRXCTL
-   "  -t         : enable RTS RS-485 data direction control\n"
+   "  -t         : enable RTS RS-485 data direction control using RTS\n"
+   "  -y         : enable RTS RS-485 data direction control using sysfs file, active transmit\n"
+   "  -Y         : enable RTS RS-485 data direction control using sysfs file, active receive\n"
 #endif
 #ifdef LOG
 #ifdef DEBUG
@@ -165,7 +167,7 @@ main(int argc, char *argv[])
   while ((rc = getopt(argc, argv,
                "dh"
 #ifdef TRXCTL
-               "t"
+               "ty:Y:"
 #endif
 #ifdef LOG
                "v:L:"
@@ -183,6 +185,14 @@ main(int argc, char *argv[])
       case 't':
         cfg.trxcntl = TRX_RTS;
         break;
+      case 'y':
+	cfg.trxcntl = TRX_SYSFS_1;
+        strncpy(cfg.trxcntl_file, optarg, INTBUFSIZE);
+	break;
+      case 'Y':
+	cfg.trxcntl = TRX_SYSFS_0;
+        strncpy(cfg.trxcntl_file, optarg, INTBUFSIZE);
+	break;
 #endif
 #ifdef LOG
       case 'v':

--- a/src/tty.c
+++ b/src/tty.c
@@ -362,20 +362,44 @@ tty_close(ttydata_t *mod)
 }
 
 #ifdef  TRXCTL
+void sysfs_gpio_set(char *filename, char *value) {
+	int fd;
+
+	fd = open(filename, O_WRONLY);
+	/* write first byte. Should only be 0 or 1 */
+	write(fd, value, 1);
+	close(fd);
+
+	logw(9, "tty: sysfs_gpio_set(%s,%s)\n",filename,value);
+
+}
+
 /* Set RTS line to active state */
 void
 tty_set_rts(int fd)
 {
-  int mstat = TIOCM_RTS;
-  ioctl(fd, TIOCMBIS, &mstat);
+	if ( TRX_RTS == cfg.trxcntl ) {
+		int mstat = TIOCM_RTS;
+		ioctl(fd, TIOCMBIS, &mstat);
+	} else if ( TRX_SYSFS_1 == cfg.trxcntl) {
+		sysfs_gpio_set(cfg.trxcntl_file,"1");
+	} else if ( TRX_SYSFS_0 == cfg.trxcntl) {
+		sysfs_gpio_set(cfg.trxcntl_file,"0");
+	}
 }
 
 /* Set RTS line to passive state */
 void
 tty_clr_rts(int fd)
 {
-  int mstat = TIOCM_RTS;
-  ioctl(fd, TIOCMBIC, &mstat);
+	if ( TRX_RTS == cfg.trxcntl ) {
+		int mstat = TIOCM_RTS;
+		ioctl(fd, TIOCMBIC, &mstat);
+	} else if ( TRX_SYSFS_1 == cfg.trxcntl) {
+		sysfs_gpio_set(cfg.trxcntl_file,"0");
+	} else if ( TRX_SYSFS_0 == cfg.trxcntl) {
+		sysfs_gpio_set(cfg.trxcntl_file,"1");
+	}
 }
 #endif
 

--- a/src/tty.h
+++ b/src/tty.h
@@ -67,8 +67,10 @@
  * TRX control types
  */
 #ifdef  TRXCTL
-#define TRX_ADDC 0
-#define TRX_RTS  1
+#define TRX_ADDC    0
+#define TRX_RTS     1
+#define TRX_SYSFS_1 2
+#define TRX_SYSFS_0 3
 #endif
 
 /*
@@ -89,7 +91,7 @@ typedef struct
   int speed;                    /* serial port speed */
   char *port;                   /* serial port device name */
 #ifdef TRXCTL
-  int trxcntl;                  /* trx control type (0 - Automatic Data Direction Control (ADDC), 1 - by RTS) */
+  int trxcntl;                  /* trx control type (enum - see values in config.h) */
 #endif
   struct termios tios;          /* working termios structure */
   struct termios savedtios;     /* saved termios structure */


### PR DESCRIPTION
Change added functionality to allow to write a 0 or 1 to a file to enable or disable the RS-485 transmitter. Existing RTS functionality was extended by adding two more options. -y filename flag will cause mbusd to write a 1 to filename when the transmitter should be enabled and a 0 to filename when transmitter should be disabled. -Y is the inverse of this.

This functionality can be used with sysfs gpio support (https://www.kernel.org/doc/Documentation/gpio/sysfs.txt) to drive a GPIO. This is useful on embedded systems such as Raspberry PI.

This is my first time doing a brach / pull request to an outside source. Hopefully I did it right.