### PR TITLE
Cmake gitlabci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ build:fedora_x86:
   image: fedora:latest
   stage: build
   before_script:
-    - yum -y install cmake pkgconfig gcc-c++
+    - yum -y install cmake pkgconfig gcc-c++ rpmbuild
   script:
     - mkdir output.dir/
     - cd output.dir
@@ -46,7 +46,7 @@ build:deb_x86:
  stage: build
  before_script:
    - apt update -qq
-   - apt install -y -qq build-essential pkg-config cmake rpmbuild
+   - apt install -y -qq build-essential pkg-config cmake
  script:
    - mkdir output.dir/
    - cd output.dir

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ build:fedora_x86:
   image: fedora:latest
   stage: build
   before_script:
-    - yum -y install cmake gcc-c++
+    - yum -y install cmake pkgconfig gcc-c++
   script:
     - mkdir output.dir/
     - cd output.dir

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ build:deb_armhf:
  script:
    - mkdir output.dir/
    - cd output.dir
-   - cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../cmake/arm_linux_gnueabihf.cmake ../
+   - cmake -DCMAKE_BUILD_TYPE=Release -DSYSTEMD_SERVICES_INSTALL_DIR=/lib/systemd/system -DCMAKE_TOOLCHAIN_FILE=../cmake/arm_linux_gnueabihf.cmake ../
    - make package
 
 build:deb_x86:
@@ -38,7 +38,7 @@ build:deb_x86:
  script:
    - mkdir output.dir/
    - cd output.dir
-   - cmake -D CMAKE_BUILD_TYPE=Debug ../
+   - cmake -DCMAKE_BUILD_TYPE=Release -DSYSTEMD_SERVICES_INSTALL_DIR=/lib/systemd/system ../
    - make package
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ stages:
   artifacts:
     # create an archive with a name of the current stage and branch name
     name: "${CI_BUILD_STAGE}_${CI_BUILD_REF_NAME}"
-    expire_in: 1 day
+    expire_in: 6 months
     paths:
       - output.dir/mbusd
       - output.dir/mbusd.8

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ build:fedora_x86:
   image: fedora:latest
   stage: build
   before_script:
-    - yum -y install cmake pkgconfig gcc-c++ rpmbuild
+    - yum -y install cmake pkgconfig gcc-c++ rpmdevtools
   script:
     - mkdir output.dir/
     - cd output.dir

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,7 +46,7 @@ build:deb_x86:
  stage: build
  before_script:
    - apt update -qq
-   - apt install -y -qq build-essential pkg-config cmake rpmdevtools
+   - apt install -y -qq build-essential pkg-config cmake rpmbuild
  script:
    - mkdir output.dir/
    - cd output.dir

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,18 @@ stages:
       - output.dir/mbusd*.deb
       - output.dir/mbusd*.rpm
 
+build:fedora_x86:
+  <<: *mbusd_job_template
+  image: fedora:latest
+  stage: build
+  before_script:
+    - yum -y install cmake gcc-c++
+  script:
+    - mkdir output.dir/
+    - cd output.dir
+    - cmake -D CMAKE_BUILD_TYPE=Debug ../
+    - make package
+
 build:deb_armhf:
  <<: *mbusd_job_template
  stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ build:fedora_x86:
   script:
     - mkdir output.dir/
     - cd output.dir
-    - cmake -D CMAKE_BUILD_TYPE=Debug ../
+    - cmake -D CMAKE_BUILD_TYPE=Debug -DSYSTEMD_SERVICES_INSTALL_DIR=/usr/lib/systemd/system ../
     - make package
 
 build:deb_armhf:
@@ -46,7 +46,7 @@ build:deb_x86:
  stage: build
  before_script:
    - apt update -qq
-   - apt install -y -qq build-essential pkg-config cmake
+   - apt install -y -qq build-essential pkg-config cmake rpmdevtools
  script:
    - mkdir output.dir/
    - cd output.dir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ execute_process(
 ## issue the package creation with $make package
 # which infrastructure do we want
 set(CPACK_GENERATOR "DEB")
-pkg_check_modules(rpmBuilder "librpmbuild3")
+pkg_check_modules(rpmBuilder "rpmbuild")
 if(rpmBuilder_FOUND)
     set(CPACK_GENERATOR "RPM")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ install(
         DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/${CMAKE_PROJECT_NAME}
 )
 
-if(SYSTEMD_FOUND)
+if(SYSTEMD_SERVICES_INSTALL_DIR)
     message(STATUS "Systemd service file will be installed to ${SYSTEMD_SERVICES_INSTALL_DIR}")
     # aggregate mbusd@.service from its template
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/systemd-units/mbusd@.service.in mbusd@.service)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ execute_process(
 ## issue the package creation with $make package
 # which infrastructure do we want
 set(CPACK_GENERATOR "DEB")
-pkg_check_modules(rpmBuilder "rpmdevtools")
+pkg_check_modules(rpmBuilder "rpmbuild")
 if(rpmBuilder_FOUND)
     set(CPACK_GENERATOR "RPM")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ execute_process(
 ## issue the package creation with $make package
 # which infrastructure do we want
 set(CPACK_GENERATOR "DEB")
-pkg_check_modules(rpmBuilder "rpmbuild")
+pkg_check_modules(rpmBuilder "rpmdevtools")
 if(rpmBuilder_FOUND)
     set(CPACK_GENERATOR "RPM")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,8 @@ execute_process(
 set(CPACK_GENERATOR "DEB")
 find_program(rpmBuilder rpmbuild)
 if(rpmBuilder)
+    # @see https://schneide.wordpress.com/2013/02/11/build-a-rpm-package-using-cmake/
+    # @see http://www.g-loaded.eu/2006/04/05/how-to-build-rpm-packages-on-fedora/
     set(CPACK_GENERATOR "RPM")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,8 +123,8 @@ execute_process(
 ## issue the package creation with $make package
 # which infrastructure do we want
 set(CPACK_GENERATOR "DEB")
-pkg_check_modules(rpmBuilder "rpmbuild")
-if(rpmBuilder_FOUND)
+find_program(rpmBuilder rpmbuild)
+if(rpmBuilder)
     set(CPACK_GENERATOR "RPM")
 endif()
 

--- a/cmake/extern_GPL/FindSystemd.cmake
+++ b/cmake/extern_GPL/FindSystemd.cmake
@@ -17,7 +17,7 @@ if (SYSTEMD_FOUND AND "${SYSTEMD_SERVICES_INSTALL_DIR}" STREQUAL "")
     string(REGEX REPLACE "[ \t\n]+" "" SYSTEMD_SERVICES_INSTALL_DIR
         "${SYSTEMD_SERVICES_INSTALL_DIR}")
 elseif (NOT SYSTEMD_FOUND AND SYSTEMD_SERVICES_INSTALL_DIR)
-    message (FATAL_ERROR "Variable SYSTEMD_SERVICES_INSTALL_DIR is\
+    message (INFO "Variable SYSTEMD_SERVICES_INSTALL_DIR is\
         defined, but we can't find systemd using pkg-config")
 endif()
 

--- a/src/main.c
+++ b/src/main.c
@@ -218,7 +218,7 @@ main(int argc, char *argv[])
       case 'v':
         cfg.dbglvl = (char)strtol(optarg, NULL, 0);
 #  ifdef DEBUG
-        if (cfg.dbglvl < 0 || cfg.dbglvl > 9)
+        if (cfg.dbglvl > 9)
         { /* report about invalid log level */
           printf("%s: -v: invalid loglevel value"
                  " (%d, must be 0-9)\n", exename, cfg.dbglvl);


### PR DESCRIPTION
Although I didn't test the packages itself, it now outputs rpm packages. You can easily download the build done on Fedora at the right hand side of the [gitlab-ci page](https://gitlab.com/nickma/mbusd/pipelines).
It's doing three build atm as you can see.

Questionable is why the mbusd bin's from inside the rpm and from the "raw build" aren't the same
E.g. [artifact 44090939](https://gitlab.com/nickma/mbusd/-/jobs/44090939/artifacts/download):
md5sum mbusd*
82208e13bb5a8cd0107caa8307d5bde5  mbusd
dbfa33ca4423f9eb31892a2358ce9540  mbusd_rpm

Maybe you could test the integrity?
Apart from that you are now able to *build a rpm package by yourself* by issuing a `make package` in the output.dir.