### PR TITLE
Fixture gitlab ci build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ test_x86:
     - apt update -qq
     - apt install -y -qq build-essential pkg-config cmake
     - apt install -y -qq python-dev python-pip python-setuptools socat
-    - python -m pip install pymodbus service_identity
+    - python -m pip install pymodbus service_identity twisted
 
   dependencies:
     - build:deb_x86

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ build:fedora_x86:
   image: fedora:latest
   stage: build
   before_script:
-    - yum -y install cmake pkgconfig gcc-c++ rpmdevtools
+    - yum -y install make cmake pkgconfig gcc-c++ rpmdevtools
   script:
     - mkdir output.dir/
     - cd output.dir

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,8 +69,8 @@ test_x86:
   script:
     - mkdir -p output.dir/
     - cd output.dir
-    - cmake -DTESTS=True ../
-    - make VERBOSE=1
+    - cmake ../
+    - make
 
     # execute all tests
-    - ./test_*
+    - make VERBOSE=1 CTEST_OUTPUT_ON_FAILURE=1 test

--- a/tests/run_itests.sh
+++ b/tests/run_itests.sh
@@ -24,7 +24,7 @@ function teardown() {
 }
 trap teardown EXIT
 
-setup || exit 1
+setup || (echo "failed to setup" && exit 1)
 
 $CWD/run_itests.py || exit 1
 


### PR DESCRIPTION
* Fedora has changed in a way, that it now requires `make` to be installed explicitly
  * https://gitlab.com/nickma/mbusd/pipelines
* Test infrastructure has changed and is now a make target - using that now