### PR TITLE
cmake armhf: set CPack architecture

### DIFF
--- a/cmake/arm_linux_gnueabihf.cmake
+++ b/cmake/arm_linux_gnueabihf.cmake
@@ -1,5 +1,6 @@
 # this one is important
 SET(CMAKE_SYSTEM_NAME Linux)
+SET(CMAKE_SYSTEM_PROCESSOR armhf)
 
 # specify the cross compiler
 SET(CMAKE_C_COMPILER   /usr/bin/arm-linux-gnueabihf-gcc)
@@ -10,3 +11,6 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+# set the architecture for CPack (i.e packageing)
+set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE armhf)


### PR DESCRIPTION
Added CPACK information to the cmake armhf file, in order to comply with dpkg (tested with 1.19.0.5) architecture matching checks.

Tested [the armhf deb](https://gitlab.com/nickma/mbusd/-/jobs/143696261/artifacts/file/output.dir/mbusd-Linux_armhf-v0.3.1.deb) on Ubuntu 18.04 (armv7l).
Please see https://gitlab.com/nickma/mbusd/pipelines/42770897/builds for a concerning CI build.