### PR TITLE
python module version freeze, pymodbus pump to v2.2.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ test_x86:
     - apt update -qq
     - apt install -y -qq --no-install-recommends build-essential pkg-config cmake
     - apt install -y -qq --no-install-recommends python-dev python-pip python-setuptools socat
-    - python -m pip install pymodbus service_identity twisted
+    - python -m pip install pymodbus==2.2.0 service_identity==18.1.0 twisted==18.9.0
 
   script:
     - mkdir -p output.dir/ && cd $_

--- a/tests/environment/rtu_slave.py
+++ b/tests/environment/rtu_slave.py
@@ -14,7 +14,7 @@ import logging
 #---------------------------------------------------------------------------#
 #from pymodbus.server.async import StartTcpServer
 #from pymodbus.server.async import StartUdpServer
-from pymodbus.server.async import StartSerialServer
+from pymodbus.server.asynchronous import StartSerialServer
 
 from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSequentialDataBlock


### PR DESCRIPTION
Freezed versions on pip (python) modules, in order to not fall into backwards incompatibilities again.
Moved pymodbus async -> asynchronous.

Please see a working build at https://gitlab.com/nickma/mbusd/pipelines/57749259