### PR TITLE
Show an error when trying to use unsupported baudrate

### DIFF
--- a/src/cfg.c
+++ b/src/cfg.c
@@ -61,7 +61,7 @@ cfg_init(void)
   strncpy(cfg.logname, LOGNAME, INTBUFSIZE);
 #endif
   strncpy(cfg.ttyport, DEFAULT_PORT, INTBUFSIZE);
-  cfg.ttyspeed = DEFAULT_SPEED;
+  cfg.ttyspeed = 0;
   strncpy(cfg.ttymode, DEFAULT_MODE, INTBUFSIZE);
 #ifdef TRXCTL
   cfg.trxcntl = TRX_ADDC;

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -73,7 +73,6 @@ cfg_init(void)
   cfg.maxtry = DEFAULT_MAXTRY;
   cfg.rqstpause = DEFAULT_RQSTPAUSE;
   cfg.respwait = DEFAULT_RESPWAIT;
-  cfg.resppause = DV(3, DEFAULT_BITS_PER_CHAR, cfg.ttyspeed);
   cfg.conntimeout = DEFAULT_CONNTIMEOUT;
 }
 

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -72,8 +72,6 @@ typedef struct
   unsigned long rqstpause;
   /* response waiting time (in msec) */
   unsigned long respwait;
-  /* inter-byte response pause (in usec) */
-  unsigned long resppause;
 } cfg_t;
 
 /* Prototypes */

--- a/src/tty.c
+++ b/src/tty.c
@@ -201,7 +201,7 @@ tty_transpeed(int speed)
   switch (speed)
   {
   case 0:
-    tspeed = B0;
+    tspeed = DEFAULT_BSPEED;
     break;
 #if defined(B50)
   case 50:
@@ -312,8 +312,8 @@ tty_transpeed(int speed)
     break;
 #endif
   default:
-    tspeed = DEFAULT_BSPEED;
-    break;
+    logw(2, "unsupported baudrate (%d)", speed);
+    exit (-1);
   }
   return tspeed;
 }

--- a/src/tty.c
+++ b/src/tty.c
@@ -312,7 +312,7 @@ tty_transpeed(int speed)
     break;
 #endif
   default:
-    logw(2, "unsupported baudrate (%d)", speed);
+    logw(2, "unsupported speed (%d)", speed);
     exit (-1);
   }
   return tspeed;


### PR DESCRIPTION
I had bad times trying to figure out why baudrate I use (500000) is not working with my device while it was working well with other modbus clients. With use of logic analyzer, it turned out mbusd used the default baudrate as 500000 was not supported. I think it would be worth to report an error to the user that he selected (via `-s`) an unsupported baudrate rather than silently revert to the default one (19200).

`0` in ttyspeed is now treated as a marker of default baudrate which is then replaced with the default baudrate in `tty_transpeed` function. `default` clause just reports an error that unsupported baudrate was selected.