### PR TITLE
feature-reply-on-broadcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Usage:
               Specifies response wait time in milliseconds.
        -T timeout
               Specifies connection timeout value in seconds (0 disables timeout).
+       -b 
+              Reply on a Broadcast
 
 Please note running **mbusd** on default Modbus TCP port (502) requires root privileges!
 

--- a/conf/mbusd.conf.example
+++ b/conf/mbusd.conf.example
@@ -45,3 +45,6 @@ pause = 100
 
 # Response wait time in milliseconds
 wait = 500
+
+# Reply on Broadcast
+#replyonbroadcast

--- a/doc/mbusd.8.in
+++ b/doc/mbusd.8.in
@@ -36,6 +36,7 @@ mbusd \- MODBUS/TCP to MODBUS/RTU gateway.
 .IR wait ]
 .RB [ -T
 .IR timeout ]
+.RB [ -b ]
 .SH DESCRIPTION
 \fImbusd\fR is MODBUS/TCP to MODBUS/RTU gateway.
 .SH OPTIONS
@@ -81,6 +82,8 @@ Specifies pause between requests in milliseconds.
 Specifies response wait time in milliseconds.
 .IP "\fB-T \fItimeout\fR"
 Specifies connection timeout value in seconds (0 - disable timeout).
+.IP "\fB-b\fR"
+Instruct \fImbusd\fR to reply on a broadcast
 .SH NOTES
 In case of situation when \fImbusd\fR received response with invalid CRC and can't correct
 error by re-request, it return MODBUS/TCP packet with exception code 04. In case of situation

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -74,6 +74,7 @@ cfg_init(void)
   cfg.rqstpause = DEFAULT_RQSTPAUSE;
   cfg.respwait = DEFAULT_RESPWAIT;
   cfg.conntimeout = DEFAULT_CONNTIMEOUT;
+  cfg.replyonbroadcast=0;
 }
 
 static char *
@@ -171,6 +172,10 @@ cfg_handle_param(char *name, char *value)
       CFG_ERR("invalid wait value: %s", value);
       return 0;
     }
+  }
+   else if (CFG_NAME_MATCH("replyonbroadcast"))
+  {
+    cfg.replyonbroadcast = 1;
   }
   else if (CFG_NAME_MATCH("timeout"))
   {

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -72,6 +72,8 @@ typedef struct
   unsigned long rqstpause;
   /* response waiting time (in msec) */
   unsigned long respwait;
+  /* reply to client on broadcast */
+  int replyonbroadcast;
 } cfg_t;
 
 /* Prototypes */

--- a/src/conn.c
+++ b/src/conn.c
@@ -560,12 +560,22 @@ conn_loop(void)
 #endif
           if (!tty.txbuf[0])
           {
-            /* broadcast request sent, no reply expected */
-            state_conn_set(actconn, CONN_HEADER);
-            state_tty_set(&tty, TTY_PAUSE);
 #ifdef DEBUG
             logw(5, "conn[%s]: broadcast request sent", curconn->remote_addr);
 #endif
+            /* broadcast request sent, no reply expected from TTY*/
+            state_tty_set(&tty, TTY_PAUSE);
+            if (cfg.replyonbroadcast)
+            {
+                /* switch connection to response state, reply w actconn->buf */
+                state_conn_set(actconn, CONN_RESP);
+            }
+            else
+            {
+                /* Done, ready for next */
+                state_conn_set(actconn, CONN_HEADER);
+            }
+
           }
           else
           {

--- a/src/main.c
+++ b/src/main.c
@@ -112,7 +112,7 @@ usage(char *exename)
    "             [-t] [-y sysfsfile] [-Y sysfsfile]\n"
 #endif
    "             [-A address] [-P port] [-C maxconn] [-N retries]\n"
-   "             [-R pause] [-W wait] [-T timeout]\n\n"
+   "             [-R pause] [-W wait] [-T timeout] [-b]\n\n"
    "Options:\n"
    "  -h         : this help\n"
    "  -d         : don't daemonize\n"
@@ -145,7 +145,8 @@ usage(char *exename)
    "  -W wait    : set response wait time in milliseconds\n"
    "               (1-%d, default %lu)\n"
    "  -T timeout : set connection timeout value in seconds\n"
-   "               (0-%d, default %d, 0 - no timeout)"
+   "               (0-%d, default %d, 0 - no timeout)\n"
+   "  -b         : reply on broadcast (default %d)"   
    "\n", PACKAGE, VERSION, exename,
 #ifdef LOG
       LOGPATH, LOGNAME, cfg.dbglvl,
@@ -154,7 +155,7 @@ usage(char *exename)
       cfg.serveraddr, cfg.serverport,
       MAX_MAXCONN, cfg.maxconn, MAX_MAXTRY, cfg.maxtry,
       MAX_RQSTPAUSE, cfg.rqstpause, MAX_RESPWAIT, cfg.respwait,
-      MAX_CONNTIMEOUT, cfg.conntimeout);
+      MAX_CONNTIMEOUT, cfg.conntimeout, cfg.replyonbroadcast);
   exit(0);
 }
 
@@ -184,7 +185,7 @@ main(int argc, char *argv[])
 #ifdef LOG
                "v:L:"
 #endif
-               "p:s:m:A:P:C:N:R:W:T:c:")) != RC_ERR)
+               "p:s:m:A:P:C:N:R:W:T:c:b")) != RC_ERR)
   {
     switch (rc)
     {
@@ -349,6 +350,9 @@ main(int argc, char *argv[])
                  " (%d, must be 1-%d)\n", exename, cfg.conntimeout, MAX_CONNTIMEOUT);
           exit(-1);
         }
+        break;
+      case 'b':
+        cfg.replyonbroadcast = 1;
         break;
       case 'h':
         usage(exename);


### PR DESCRIPTION
# Reply on Broadcast

## Purpose

Some ModBus libraries don't support Broadcast `unitId=0` over tcp/ip what creates timeout and/or error condition in the tcp client.
While `mbusd` is already prepared  not to wait for a reply on a Broadcast, `mbusd` does not send an answer to the client.

## Change:

This merge request adds the option `-b` to `mbusd` startup options and `replyonbroadcast` as config file option to enable the reply on a Broadcast, defaulting to `NO REPLY ON BROADCAST`.
Updates the `man mbus` and `mbusd -h` or usage:

```
Usage: mbusd [-h] [-d] [-L logfile] [-v level] [-c cfgfile]
             [-p device] [-s speed] [-m mode]
             [-t] [-y sysfsfile] [-Y sysfsfile]
             [-A address] [-P port] [-C maxconn] [-N retries]
             [-R pause] [-W wait] [-T timeout] [-b]

Options:
  -h         : this help
  -d         : don't daemonize
  -L logfile : set log file name (default /var/log/mbus.log,
               '-' for logging to STDOUT only)
  -v level   : set log level (0-9, default 2, 0 - errors only)
  -c cfgfile : read configuration from cfgfile
  -p device  : set serial port device name (default /dev/ttyS0)
  -s speed   : set serial port speed (default 19200)
  -m mode    : set serial port mode (default 8N1)
  -A address : set TCP server address to bind (default 0.0.0.0)
  -P port    : set TCP server port number (default 502)
  -t         : enable RTS RS-485 data direction control using RTS
  -y         : enable RTS RS-485 data direction control using sysfs file, active transmit
  -Y         : enable RTS RS-485 data direction control using sysfs file, active receive
  -C maxconn : set maximum number of simultaneous TCP connections
               (1-128, default 32)
  -N retries : set maximum number of request retries
               (0-15, default 3, 0 - without retries)
  -R pause   : set pause between requests in milliseconds
               (1-10000, default 100)
  -W wait    : set response wait time in milliseconds
               (1-10000, default 500)
  -T timeout : set connection timeout value in seconds
               (0-1000, default 60, 0 - no timeout)
  -b         : reply on broadcast (default 0)
```

## Test w pymodbus

```
    client = ModbusClient('localhost', port=1501)
    client.connect()
    rq = client.write_register(1, 10, unit=0)
```
**Remark:** *Without the pymodbus.client  `broadcast_enable=True`, to simulate libraries that don't have the `broadcast_enable` on a tcp modbus connection.*

### original or new without `-b`

```
2021-06-19 13:06:17,583 MainThread      DEBUG    sync           :215      Connection to Modbus server established. Socket ('127.0.0.1', 52444)
2021-06-19 13:06:17,583 MainThread      DEBUG    transaction    :139      Current transaction state - IDLE
2021-06-19 13:06:17,583 MainThread      DEBUG    transaction    :144      Running transaction 1
2021-06-19 13:06:17,583 MainThread      DEBUG    transaction    :272      SEND: 0x0 0x1 0x0 0x0 0x0 0x6 0x0 0x6 0x0 0x1 0x0 0xa
2021-06-19 13:06:17,583 MainThread      DEBUG    sync           :76       New Transaction state 'SENDING'
2021-06-19 13:06:17,583 MainThread      DEBUG    transaction    :286      Changing transaction state from 'SENDING' to 'WAITING FOR REPLY'
2021-06-19 13:06:20,587 MainThread      DEBUG    transaction    :302      Transaction failed. (Modbus Error: [Invalid Message] No response received, expected at least 8 bytes (0 received))
2021-06-19 13:06:20,587 MainThread      DEBUG    socket_framer  :147      Processing:
2021-06-19 13:06:20,587 MainThread      DEBUG    transaction    :464      Getting transaction 1
2021-06-19 13:06:20,587 MainThread      DEBUG    transaction    :224      Changing transaction state from 'PROCESSING REPLY' to 'TRANSACTION_COMPLETE'
Traceback (most recent call last):
  File "/Users/dgoo2308/git/modbus_test/c.py", line 101, in <module>
    run_sync_client()
  File "/Users/dgoo2308/git/modbus_test/c.py", line 60, in run_sync_client
    assert(not rq.isError())     # test that we are not an error
AssertionError
```

### mbusd -b

```
2021-06-19 13:01:55,616 MainThread      DEBUG    sync           :215      Connection to Modbus server established. Socket ('127.0.0.1', 52156)
2021-06-19 13:01:55,616 MainThread      DEBUG    transaction    :139      Current transaction state - IDLE
2021-06-19 13:01:55,616 MainThread      DEBUG    transaction    :144      Running transaction 1
2021-06-19 13:01:55,616 MainThread      DEBUG    transaction    :272      SEND: 0x0 0x1 0x0 0x0 0x0 0x6 0x0 0x6 0x0 0x1 0x0 0xa
2021-06-19 13:01:55,616 MainThread      DEBUG    sync           :76       New Transaction state 'SENDING'
2021-06-19 13:01:55,616 MainThread      DEBUG    transaction    :286      Changing transaction state from 'SENDING' to 'WAITING FOR REPLY'
2021-06-19 13:01:55,618 MainThread      DEBUG    transaction    :374      Changing transaction state from 'WAITING FOR REPLY' to 'PROCESSING REPLY'
2021-06-19 13:01:55,618 MainThread      DEBUG    transaction    :296      RECV: 0x0 0x1 0x0 0x0 0x0 0x6 0x0 0x6 0x0 0x1 0x0 0xa
2021-06-19 13:01:55,618 MainThread      DEBUG    socket_framer  :147      Processing: 0x0 0x1 0x0 0x0 0x0 0x6 0x0 0x6 0x0 0x1 0x0 0xa
2021-06-19 13:01:55,618 MainThread      DEBUG    factory        :266      Factory Response[WriteSingleRegisterResponse: 6]
2021-06-19 13:01:55,618 MainThread      DEBUG    transaction    :453      Adding transaction 1
2021-06-19 13:01:55,618 MainThread      DEBUG    transaction    :464      Getting transaction 1
2021-06-19 13:01:55,618 MainThread      DEBUG    transaction    :224      Changing transaction state from 'PROCESSING REPLY' to 'TRANSACTION_COMPLETE'
2021-06-19 13:01:55,618 MainThread      DEBUG    transaction    :139      Current transaction state - TRANSACTION_COMPLETE
```
## test libmodbus

ModBus version: `3.1.6`

```
#include <modbus/modbus.h>
int main(int argc, const char * argv[]){
   modbus_t * ctx=modbus_new_tcp_pi("mbus-5", "502");
   modbus_set_slave(ctx,0);
   modbus_set_debug(ctx, TRUE);
   modbus_write_bits(ctx, 229, 1, &data);
   modbus_close(ctx);
   modbus_free(ctx);
  return 0;
}
```

### original or new without `-b`
```
[00][01][00][00][00][08][00][0F][00][E5][00][01][01][01]
Waiting for a confirmation...
ERROR Connection timed out: select
```

### mbusd -b

```
[00][01][00][00][00][08][00][0F][00][E5][00][01][01][01]
Waiting for a confirmation...
<00><01><00><00><00><08><00><0F><00><E5><00><01>
OK
```
