### PR TITLE
Do not segfault when closing last connection

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -192,6 +192,7 @@ conn_close(conn_t *conn)
   nextconn = queue_next_elem(&queue, conn);
   /* dequeue connection */
   queue_delete_elem(&queue, conn);
+  if (nextconn == conn) nextconn = NULL;
   if (actconn == conn) actconn = nextconn;
   return nextconn;
 }

--- a/src/queue.c
+++ b/src/queue.c
@@ -115,5 +115,5 @@ queue_delete_elem(queue_t *queue, conn_t *conn)
 conn_t *
 queue_next_elem(queue_t *queue, conn_t *conn)
 {
-  return (conn->next == NULL) ? queue->beg : conn->next;
+  return (conn == NULL || conn->next == NULL) ? queue->beg : conn->next;
 }


### PR DESCRIPTION
When there is a single item in the `queue`, `queue_next_elem` returns that same and only item, so, in the function `conn_close`, `nextconn` is `conn`.
Afterwards, `conn` is deleted, which is also `nextconn`, so, `conn_close` returns a pointer to a freed connection.
This patch sets the return value of `conn_close` to `NULL` when there are no more connections.
