### PR TITLE
Add new flag (-r) to support inverted RTS flow control

### DIFF
--- a/src/cfg.c
+++ b/src/cfg.c
@@ -202,7 +202,11 @@ cfg_handle_param(char *name, char *value)
     }
     else if (CFG_VALUE_MATCH("rts"))
     {
-      cfg.trxcntl = TRX_RTS;
+      cfg.trxcntl = TRX_RTS_1;
+    }
+    else if (CFG_VALUE_MATCH("rts_0"))
+    {
+      cfg.trxcntl = TRX_RTS_0;
     }
     else if (CFG_VALUE_MATCH("sysfs_0"))
     {

--- a/src/main.c
+++ b/src/main.c
@@ -139,7 +139,8 @@ usage(char *exename)
    "  -A address : set TCP server address to bind (default %s)\n"
    "  -P port    : set TCP server port number (default %d)\n"
 #ifdef TRXCTL
-   "  -t         : enable RTS RS-485 data direction control using RTS\n"
+   "  -t         : enable RTS RS-485 data direction control using RTS, active transmit\n"
+   "  -r         : enable RTS RS-485 data direction control using RTS, active receive\n"
    "  -y         : enable RTS RS-485 data direction control using sysfs file, active transmit\n"
    "  -Y         : enable RTS RS-485 data direction control using sysfs file, active receive\n"
 #endif
@@ -218,7 +219,10 @@ main(int argc, char *argv[])
         break;
 #ifdef TRXCTL
       case 't':
-        cfg.trxcntl = TRX_RTS;
+        cfg.trxcntl = TRX_RTS_1;
+        break;
+      case 'r':
+        cfg.trxcntl = TRX_RTS_0;
         break;
       case 'y':
         cfg.trxcntl = TRX_SYSFS_1;

--- a/src/tty.c
+++ b/src/tty.c
@@ -469,10 +469,13 @@ void sysfs_gpio_set(char *filename, char *value) {
 void
 tty_set_rts(int fd)
 {
-	if ( TRX_RTS == cfg.trxcntl ) {
+	if ( TRX_RTS_1 == cfg.trxcntl ) {
 		int mstat = TIOCM_RTS;
 		ioctl(fd, TIOCMBIS, &mstat);
-	} else if ( TRX_SYSFS_1 == cfg.trxcntl) {
+	} else if ( TRX_RTS_0 == cfg.trxcntl ) {
+		int mstat = TIOCM_RTS;
+		ioctl(fd, TIOCMBIC, &mstat);
+  } else if ( TRX_SYSFS_1 == cfg.trxcntl) {
 		sysfs_gpio_set(cfg.trxcntl_file,"1");
 	} else if ( TRX_SYSFS_0 == cfg.trxcntl) {
 		sysfs_gpio_set(cfg.trxcntl_file,"0");
@@ -483,9 +486,12 @@ tty_set_rts(int fd)
 void
 tty_clr_rts(int fd)
 {
-	if ( TRX_RTS == cfg.trxcntl ) {
+	if ( TRX_RTS_1 == cfg.trxcntl ) {
 		int mstat = TIOCM_RTS;
 		ioctl(fd, TIOCMBIC, &mstat);
+	} else if ( TRX_RTS_0 == cfg.trxcntl ) {
+		int mstat = TIOCM_RTS;
+		ioctl(fd, TIOCMBIS, &mstat);
 	} else if ( TRX_SYSFS_1 == cfg.trxcntl) {
 		sysfs_gpio_set(cfg.trxcntl_file,"0");
 	} else if ( TRX_SYSFS_0 == cfg.trxcntl) {

--- a/src/tty.h
+++ b/src/tty.h
@@ -77,9 +77,10 @@
  */
 #ifdef  TRXCTL
 #define TRX_ADDC    0
-#define TRX_RTS     1
-#define TRX_SYSFS_1 2
-#define TRX_SYSFS_0 3
+#define TRX_RTS_1   1
+#define TRX_RTS_0   2
+#define TRX_SYSFS_1 3
+#define TRX_SYSFS_0 4
 #endif
 
 /*


### PR DESCRIPTION
This is useful if you have a MAX485 connected to a Raspberry PI where you pull want RST low to transmit.

- I would have liked to use -T to match -y/-Y, but this is already used. I've proposed -r to keep CLI-flag backwards compatibility.
- I've also left the config file setting as "rts" so as to preserve backwards compatibility. 