### PR TITLE
Implement IOCTL control of RS-485 transmitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ cmake_install.cmake
 .project
 .cproject
 build
+build-arm

--- a/conf/mbusd.conf.example
+++ b/conf/mbusd.conf.example
@@ -15,11 +15,42 @@ speed = 9600
 # Serial port mode
 mode = 8n1
 
-# RS-485 data direction control type (addc, rts, sysfs_0, sysfs_1)
+# RS-485 data direction control type (addc, rts, sysfs_0, sysfs_1, ioctl)
 trx_control = addc
 
 # Sysfs file to use to control data direction
 # trx_sysfile =
+
+# Example IOCTL configuration
+
+#trx_control = ioctl
+#trx_sysfile = /dev/gpio_ctl
+
+# IOCTL request number
+
+#trx_ioctl_req = 0x40080004
+
+# IOCTL argument type (long, struct)
+
+# "long" argument example
+
+#trx_ioctl_arg_type = long
+
+# 1 when RTS set, 0 when clear
+# rts_inv for inverse
+#trx_ioctl_val = rts
+
+
+# "struct" argument example
+
+#trx_ioctl_arg_type = struct
+
+#trx_ioctl_val_1 = 0
+
+# 1 when RTS set, 0 when clear
+# rts_inv for inverse
+#trx_ioctl_val_2 = rts
+
 
 ############# TCP port settings #############
 

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -58,6 +58,18 @@ typedef struct
   int trxcntl;
   /* trx control sysfs file */
   char trxcntl_file[INTBUFSIZE + 1];
+  /* trx IOCTL request number */
+  unsigned long trx_ioctl_req;
+  /* trx IOCTL argument type */
+  int trx_ioctl_arg_type;
+  /* trx IOCTL argument */
+  unsigned long trx_ioctl_arg_long;
+  unsigned long *trx_ioctl_arg_struct;
+  int trx_ioctl_rts_value_num;
+  int trx_ioctl_rts_value_invert;
+  /* number of values in IOCTL argument (if struct type) */
+  int trx_ioctl_num_values;
+  /* 
   /* TCP server address */
   char serveraddr[INTBUFSIZE + 1];
   /* TCP server port number */

--- a/src/tty.c
+++ b/src/tty.c
@@ -439,7 +439,51 @@ void sysfs_gpio_set(char *filename, char *value) {
 	write(fd, value, 1);
 	close(fd);
 
+#ifdef LOG
 	logw(9, "tty: sysfs_gpio_set(%s,%s)\n",filename,value);
+#endif
+
+}
+
+void sysfs_gpio_ioctl(char *filename, int set) {
+	int fd;
+
+#ifdef LOG
+	logw(9, "tty: sysfs_gpio_ioctl(%s,%d)\n",filename,set);
+#endif
+
+    if (cfg.trx_ioctl_rts_value_invert)
+      set = !set;
+
+    if (cfg.trx_ioctl_rts_value_num > 0)
+    {
+      if (cfg.trx_ioctl_arg_type == TRX_IOCTL_ARG_STRUCT)
+        cfg.trx_ioctl_arg_struct[cfg.trx_ioctl_rts_value_num - 1] = set;
+      else if (cfg.trx_ioctl_arg_type == TRX_IOCTL_ARG_LONG)
+        cfg.trx_ioctl_arg_long = set;
+    }
+
+	fd = open(filename, O_WRONLY);
+	if (cfg.trx_ioctl_arg_type == TRX_IOCTL_ARG_LONG)
+		ioctl(fd, cfg.trx_ioctl_req, cfg.trx_ioctl_arg_long);
+	else if (cfg.trx_ioctl_arg_type == TRX_IOCTL_ARG_STRUCT)
+		ioctl(fd, cfg.trx_ioctl_req, cfg.trx_ioctl_arg_struct);
+
+	close(fd);
+
+#ifdef LOG
+    logw(9, "tty: ioctl request = 0x%lx\n",cfg.trx_ioctl_req);
+
+    if (cfg.trx_ioctl_arg_type == TRX_IOCTL_ARG_LONG)
+      logw(9, "tty: ioctl arg = 0x%lx\n",cfg.trx_ioctl_arg_long);
+
+    if (cfg.trx_ioctl_arg_type == TRX_IOCTL_ARG_STRUCT)
+    {
+      logw(9, "tty: ioctl struct: %d values\n",cfg.trx_ioctl_num_values);
+      for(int i = 0; i < cfg.trx_ioctl_num_values; i++)
+        logw(9, "tty: ioctl struct value %d = 0x%lx\n",i,cfg.trx_ioctl_arg_struct[i]);
+    }
+#endif
 
 }
 
@@ -454,7 +498,10 @@ tty_set_rts(int fd)
 		sysfs_gpio_set(cfg.trxcntl_file,"1");
 	} else if ( TRX_SYSFS_0 == cfg.trxcntl) {
 		sysfs_gpio_set(cfg.trxcntl_file,"0");
+	} else if ( TRX_IOCTL == cfg.trxcntl) {
+		sysfs_gpio_ioctl(cfg.trxcntl_file,1);
 	}
+
 }
 
 /* Set RTS line to passive state */
@@ -468,7 +515,10 @@ tty_clr_rts(int fd)
 		sysfs_gpio_set(cfg.trxcntl_file,"0");
 	} else if ( TRX_SYSFS_0 == cfg.trxcntl) {
 		sysfs_gpio_set(cfg.trxcntl_file,"1");
+	} else if ( TRX_IOCTL == cfg.trxcntl) {
+		sysfs_gpio_ioctl(cfg.trxcntl_file,0);
 	}
+
 }
 #endif
 

--- a/src/tty.h
+++ b/src/tty.h
@@ -76,6 +76,13 @@
 #define TRX_RTS     1
 #define TRX_SYSFS_1 2
 #define TRX_SYSFS_0 3
+#define TRX_IOCTL   4
+
+/*
+ * TRX IOCTL argument types
+ */
+#define TRX_IOCTL_ARG_LONG   0
+#define TRX_IOCTL_ARG_STRUCT 1
 #endif
 
 /*


### PR DESCRIPTION
Added ability to configure IOCTL control of GPIO pins for RS-485 transmit/receive. Also fixed bug in configuration file parsing of "loglevel" parameter.