### PR TITLE
Add one char delay before switching TRX control, fixed warnings

### DIFF
--- a/src/cfg.c
+++ b/src/cfg.c
@@ -50,7 +50,7 @@ cfg_t cfg;
 /* Configuration error message */
 char cfg_err[INTBUFSIZE + 1];
 
-#define CFG_ERR(s, v) snprintf(cfg_err, INTBUFSIZE, s, v)
+#define CFG_ERR(...) snprintf(cfg_err, INTBUFSIZE, __VA_ARGS__)
 
 /*
  * Setting up config defaults
@@ -232,7 +232,7 @@ cfg_handle_param(char *name, char *value)
   {
     if (!strlen(value))
     {
-      CFG_ERR("missing logfile value", value);
+      CFG_ERR("missing logfile value");
       return 0;
     }
     else if (*value != '/')

--- a/src/conn.c
+++ b/src/conn.c
@@ -266,7 +266,8 @@ conn_write(int d, void *buf, size_t nbytes, int istty)
 #ifdef TRXCTL
   if (istty && cfg.trxcntl != TRX_ADDC )
   {
-    tty_delay(DV(nbytes, tty.bpc, cfg.ttyspeed));
+    // one char more delay to prevent too early GPIO switch on some HW
+    tty_delay(DV((nbytes + 1), tty.bpc, cfg.ttyspeed));
     tty_set_rx(d);
   }
 #endif

--- a/src/conn.c
+++ b/src/conn.c
@@ -245,8 +245,6 @@ conn_write(int d, void *buf, size_t nbytes, int istty)
 {
   int rc;
   fd_set fs;
-  struct timeval ts, tts;
-  long delay;
 
 #ifdef TRXCTL
   if (istty && cfg.trxcntl != TRX_ADDC)
@@ -840,7 +838,7 @@ conn_loop(void)
               if (curconn->ctr >= MB_DATA_NBYTES)
               {
                 /* compute request data length for fc 15/16 */
-                unsigned int len;
+                unsigned int len = 0;
                 switch (MB_FRAME(curconn->buf, MB_FCODE))
                 {
                   case 15: /* Force Multiple Coils */

--- a/src/main.c
+++ b/src/main.c
@@ -194,7 +194,7 @@ main(int argc, char *argv[])
   while ((rc = getopt(argc, argv,
                "dh"
 #ifdef TRXCTL
-               "ty:Y:"
+               "try:Y:"
 #endif
 #ifdef HAVE_TIOCRS485
                "S"


### PR DESCRIPTION
Added one char to TRX control delay, when switching back to read. This prevents hazardous states on CPUs, where is the UART "slow" and switching the GPIO pin can be faster, then finishing sending of the data (e.g. Rockchip RK3328).

Modbus specs says, that delay between two frames must be at least t3.5 chars for bauds <= 19200 and 1.75ms for higher bauds, so this modifications should be safe.

Tested on RockPi E and BeagleBone black.

Fixed also some compiler warnings and non working -r argument.